### PR TITLE
Update dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.2",
-        "laravel/framework": "^7.0|^8.40"
+        "php": "^7.2|^8.0",
+        "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.10"


### PR DESCRIPTION
Bump php requirement to 8.0 and drop laravel/framework: 8.0 in favour of illuminate/support up to 9.0.
This will allow for laravel support up to versino 9.